### PR TITLE
Renaming `:inn` validator to `:inn_format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+### not released yet
+
+* InnValidator and KppValidator were renamed to InnFormat and KppFormat validators
+
 ### 0.0.3
 
-InnValidator
+* InnValidator added
 
 ### 0.0.2
 
-KppValidator
+* KppValidator added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ```ruby
 class Legal < ActiveRecord::Base
-  validates :kpp, kpp: true
+  validates :kpp, kpp_format: true
 end
 
 # legal = Legal.new

--- a/doc/english_readme.md
+++ b/doc/english_readme.md
@@ -25,7 +25,7 @@ Add to Gemfile
 
 ```ruby
 class Legal < ActiveRecord::Base
-  validates :kpp, kpp: true
+  validates :kpp, kpp_format: true
 end
 
 # legal = Legal.new

--- a/lib/validators/inn_format_validator.rb
+++ b/lib/validators/inn_format_validator.rb
@@ -1,4 +1,4 @@
-class InnValidator < ValidatesRussian::Validator
+class InnFormatValidator < ValidatesRussian::Validator
   validates_using do |inn|
     next false unless ValidatesRussian::REGION_NUMBERS.include?(inn[0..1])
     next false unless inn =~ /^\d+$/

--- a/lib/validators/kpp_format_validator.rb
+++ b/lib/validators/kpp_format_validator.rb
@@ -1,5 +1,5 @@
-# http://vipiskaegrul.ru/slovar-terminov/kod-prichiny-postanovki-kpp.html
-class KppValidator < ValidatesRussian::Validator
+class KppFormatValidator < ValidatesRussian::Validator
+  # see format here: http://vipiskaegrul.ru/slovar-terminov/kod-prichiny-postanovki-kpp.html
   validates_using do |kpp|
     next false unless kpp.size == 9
     next false unless ValidatesRussian::REGION_NUMBERS.include?(kpp[0..1])

--- a/spec/validators/inn_format_validator_spec.rb
+++ b/spec/validators/inn_format_validator_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe InnValidator do
+describe InnFormatValidator do
   before(:each) do
     TestModel.reset_callbacks(:validate)
-    TestModel.validates(:field, inn: true)
+    TestModel.validates(:field, inn_format: true)
   end
 
   it 'should be valid for valid values' do

--- a/spec/validators/kpp_format_validator_spec.rb
+++ b/spec/validators/kpp_format_validator_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe KppValidator do
+describe KppFormatValidator do
   before(:each) do
     TestModel.reset_callbacks(:validate)
-    TestModel.validates(:field, kpp: true)
+    TestModel.validates(:field, kpp_format: true)
   end
 
   it 'should be valid for valid values' do


### PR DESCRIPTION
I guess, `kpp_format` is more meaningful.
