### PR TITLE
OkpoFormatValidator fix

### DIFF
--- a/lib/validators/okpo_format_validator.rb
+++ b/lib/validators/okpo_format_validator.rb
@@ -11,6 +11,13 @@ class OkpoFormatValidator < ValidatesRussian::Validator
   private
 
   def self.calc(okpo)
-    okpo[0..-2].each_with_index.inject(0){ |s, p| s + p[0] * (p[1] + 1) } % 11 % 10
+    nums = okpo[0..-2]
+    check_digit = weight(nums, 1) % 11
+    check_digit = weight(nums, 3) % 11 if check_digit == 10
+    check_digit == 10 ? 0 : check_digit
+  end
+
+  def self.weight(nums, shift)
+    nums.each_with_index.inject(0) { |a, e| a + e[0] * (e[1] + shift) }
   end
 end

--- a/spec/validators/okpo_format_validator_spec.rb
+++ b/spec/validators/okpo_format_validator_spec.rb
@@ -10,7 +10,8 @@ describe OkpoFormatValidator do
     valid_okpos = %w{
       57972160
       13410254
-      74917270
+      74917277
+      00002810
       99874891
       75249303
       99874891


### PR DESCRIPTION
Изменил расчёт контрольного числа ОКПО в соответствии с:

https://ru.wikipedia.org/wiki/%D0%9A%D0%BE%D0%BD%D1%82%D1%80%D0%BE%D0%BB%D1%8C%D0%BD%D0%BE%D0%B5_%D1%87%D0%B8%D1%81%D0%BB%D0%BE#.D0.9D.D0.BE.D0.BC.D0.B5.D1.80_.D0.9E.D0.9A.D0.9F.D0.9E

в текущей версии, вот это не учитывается:

*Если получается остаток, равный 10, то для обеспечения одноразрядного контрольного числа необходимо провести повторный расчет, применяя вторую последовательность весов, сдвинутую на два разряда влево (3, 4, 5,…). Если в случае повторного расчета остаток от деления вновь сохраняется равным 10, то значение контрольного числа проставляется равным «0».*