### PR TITLE
Fix bug validate OKPO

### DIFF
--- a/lib/validators/okpo_format_validator.rb
+++ b/lib/validators/okpo_format_validator.rb
@@ -18,6 +18,10 @@ class OkpoFormatValidator < ValidatesRussian::Validator
   end
 
   def self.weight(nums, shift)
-    nums.each_with_index.inject(0) { |a, e| a + e[0] * (e[1] + shift) }
+    nums.each_with_index.inject(0) { |a, e| a + e[0] * calc_weight(e[1] + shift) }
+  end
+
+  def self.calc_weight(num)
+    num == 11 ? 1 : num
   end
 end

--- a/spec/validators/okpo_format_validator_spec.rb
+++ b/spec/validators/okpo_format_validator_spec.rb
@@ -16,6 +16,7 @@ describe OkpoFormatValidator do
       75249303
       99874891
       0060621966
+      0174266916
     }
 
     valid_okpos.each do |okpo|


### PR DESCRIPTION
Расчёт контрольного числа ОКПО не соответствует методике:

https://ru.wikipedia.org/wiki/%D0%9A%D0%BE%D0%BD%D1%82%D1%80%D0%BE%D0%BB%D1%8C%D0%BD%D0%BE%D0%B5_%D1%87%D0%B8%D1%81%D0%BB%D0%BE#.D0.9D.D0.BE.D0.BC.D0.B5.D1.80_.D0.9E.D0.9A.D0.9F.D0.9E

В данный момент не учитывается следующее:

Разрядам кода в общероссийском классификаторе, начиная со старшего разряда, присваивается набор весов, **соответствующий натуральному ряду чисел от 1 до 10. Если разрядность кода больше 10, то набор весов повторяется.**

То есть при повторном расчете контрольного числа со сдвигом разрядов последовательность весов должна выглядеть следующим образом: 3, 4, 5 ... 9, 10, 1