### PR TITLE
fix: wrong number arguments

### DIFF
--- a/lib/validates_russian/validator.rb
+++ b/lib/validates_russian/validator.rb
@@ -3,7 +3,7 @@ module ValidatesRussian
     def self.validates_using(&block)
       define_method :validate_each do |record, attribute, value|
         if block[value.to_s] == false
-          record.errors.add(attribute, attribute.to_sym, options.merge(value: value))
+          record.errors.add(attribute, attribute.to_sym, **options.merge(value: value))
         end
       end
     end


### PR DESCRIPTION
Исправляет ошибку `wrong number of arguments (given 3, expected 1..2)` [#41270](https://github.com/rails/rails/issues/41270)